### PR TITLE
Improve device inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle tag array comparison when an array contains hashes to consistently convert the hash keys to strings. Otherwise array hashes were being treated differently that other tag structures.
 
+### Changed
+
+- Improved the `inspect` method to provide a clearer representation of captured log entries to make debugging tests easier.
+
 ## 1.1.0
 
 ### Added

--- a/lib/lumberjack_capture_device.rb
+++ b/lib/lumberjack_capture_device.rb
@@ -118,6 +118,15 @@ module Lumberjack
       matches
     end
 
+    def inspect
+      message = "<##{self.class.name} #{@buffer.size} #{(@buffer.size == 1) ? "entry" : "entries"} captured:"
+      @buffer.each do |entry|
+        message << "\n  #{formatted_entry(entry)}"
+      end
+      message << "\n>"
+      message
+    end
+
     private
 
     def matched?(entry, message_filter, level_filter, tags_filter)
@@ -174,6 +183,19 @@ module Lumberjack
       else
         hash
       end
+    end
+
+    def formatted_entry(entry)
+      timestamp = entry.time.strftime("%Y-%m-%d %H:%M:%S")
+      formatted = "#{timestamp} #{entry.severity_label}: #{entry.message}"
+      formatted << "\n    progname: #{entry.progname}" if entry.progname.to_s != ""
+      formatted << "\n    pid: #{entry.pid}" if entry.pid
+      if entry.tags && !entry.tags.empty?
+        Lumberjack::Utils.flatten_tags(entry.tags).to_a.sort_by(&:first).each do |name, value|
+          formatted << "\n    #{name}: #{value}"
+        end
+      end
+      formatted
     end
   end
 end

--- a/lib/lumberjack_capture_device.rb
+++ b/lib/lumberjack_capture_device.rb
@@ -187,7 +187,7 @@ module Lumberjack
 
     def formatted_entry(entry)
       timestamp = entry.time.strftime("%Y-%m-%d %H:%M:%S")
-      formatted = "#{timestamp} #{entry.severity_label}: #{entry.message}"
+      formatted = +"#{timestamp} #{entry.severity_label}: #{entry.message}"
       formatted << "\n    progname: #{entry.progname}" if entry.progname.to_s != ""
       formatted << "\n    pid: #{entry.pid}" if entry.pid
       if entry.tags && !entry.tags.empty?

--- a/lib/lumberjack_capture_device.rb
+++ b/lib/lumberjack_capture_device.rb
@@ -119,7 +119,7 @@ module Lumberjack
     end
 
     def inspect
-      message = "<##{self.class.name} #{@buffer.size} #{(@buffer.size == 1) ? "entry" : "entries"} captured:"
+      message = +"<##{self.class.name} #{@buffer.size} #{(@buffer.size == 1) ? "entry" : "entries"} captured:"
       @buffer.each do |entry|
         message << "\n  #{formatted_entry(entry)}"
       end

--- a/spec/lumberjack_capture_device_spec.rb
+++ b/spec/lumberjack_capture_device_spec.rb
@@ -140,6 +140,7 @@ describe Lumberjack::CaptureDevice do
     it "should return a string representation of the captured entries" do
       logs = Lumberjack::CaptureDevice.capture(logger) {
         logger.info("foobar", foo: "bar")
+        logger.progname = "TestProgname"
         logger.warn("something happened", foo: {bar: "baz", bip: "bop"}, duration: 1.23)
       }
       expect(logs.inspect).to include "<#Lumberjack::CaptureDevice 2 entries captured:"

--- a/spec/lumberjack_capture_device_spec.rb
+++ b/spec/lumberjack_capture_device_spec.rb
@@ -135,4 +135,19 @@ describe Lumberjack::CaptureDevice do
       expect(logs.extract(tags: {foo: "bar"}).collect(&:message)).to eq ["foobar", "baxbar"]
     end
   end
+
+  describe "#inspect" do
+    it "should return a string representation of the captured entries" do
+      logs = Lumberjack::CaptureDevice.capture(logger) {
+        logger.info("foobar", foo: "bar")
+        logger.warn("something happened", foo: {bar: "baz", bip: "bop"}, duration: 1.23)
+      }
+      expect(logs.inspect).to include "<#Lumberjack::CaptureDevice 2 entries captured:"
+      expect(logs.inspect).to include "INFO: foobar"
+      expect(logs.inspect).to include "WARN: something happened"
+      expect(logs.inspect).to include "foo: bar"
+      expect(logs.inspect).to include "duration: 1.23"
+      expect(logs.inspect).to include "foo.bar: baz"
+    end
+  end
 end


### PR DESCRIPTION
### Changed

- Improved the `inspect` method to provide a clearer representation of captured log entries to make debugging tests easier.
